### PR TITLE
updating css for center alignment

### DIFF
--- a/jupyter_book/book_template/_layouts/default.html
+++ b/jupyter_book/book_template/_layouts/default.html
@@ -5,10 +5,8 @@
     <!-- .js-show-sidebar shows sidebar by default -->
     <div id="js-textbook" class="c-textbook {% if site.show_sidebar %}js-show-sidebar{% endif %}">
       {% include sidebar.html %}
-      {% if page.search_page != true %}
-      {% endif %}
-      {% include topbar.html %}
       <main class="c-textbook__page" tabindex="-1">
+            {% include topbar.html %}
             <div class="c-textbook__content" id="textbook_content">
               {{ content }}
             </div>

--- a/jupyter_book/book_template/_sass/components/_components.book__layout.scss
+++ b/jupyter_book/book_template/_sass/components/_components.book__layout.scss
@@ -32,13 +32,13 @@ $topbar-height: 60px;
   /* [1] */
   position: relative;
   height: 100vh;
-  overflow: hidden;
-  margin: 0 0 0 auto;
+  margin: 0 auto;
+  max-width:1600px;
 }
 
 .c-topbar {
   background-color: $book-background-color;
-  position: fixed;
+  position: absolute;
   top: 0;
   height: $topbar-height;
   width: 100%;
@@ -60,7 +60,7 @@ $topbar-height: 60px;
   /* [2] */
   height: 100vh;
   overflow: auto;
-  position: fixed;
+  position: absolute;
   background-color: $book-background-color; /* [3] */
 }
 
@@ -101,7 +101,7 @@ $topbar-height: 60px;
 }
 
 .js-show-sidebar {
-  .c-textbook__page, .c-topbar {
+  .c-textbook__page {
     /* [4] */
     transform: translate($left-sidebar-width, 0);
 


### PR DESCRIPTION
This updates the CSS so that our content centers itself in the middle of the page. Currently, on really large screens the content will all stick to the left, while the in-page TOC will float to the right. This centers the whole thing.

Right now the problem with this is that it removes the "sticky navbar" as you scroll down. I'm not sure how to keep that and make the content center in the middle :-/

closes #401 