### PR TITLE
adding an edit this page button

### DIFF
--- a/jupyter_book/book_template/_config.yml
+++ b/jupyter_book/book_template/_config.yml
@@ -85,6 +85,12 @@ use_download_button              : true  # If 'true', display a button to downlo
 download_button_text             : "Download" # The text that download buttons will contain
 download_page_header             : "Made with Jupyter Book" # A header that will be displayed at the top of and PDF-printed page
 
+# Edit settings
+use_edit_on_github_button        : true  # If true, add an "edit this page" button to the top of each page.
+edit_repo_org                    : jupyter
+edit_repo_name                   : jupyter-book
+edit_repo_branch                 : gh-pages
+
 #######################################################################################
 # Jupyter book extensions and additional features
 

--- a/jupyter_book/book_template/_includes/buttons.html
+++ b/jupyter_book/book_template/_includes/buttons.html
@@ -5,5 +5,6 @@
   {% include buttons/nbinteract.html %}
   {% include buttons/binder.html %}
   {% include buttons/jupyterhub.html %}
+  {% include buttons/github_edit.html %}
 {% endif %}
 </div>

--- a/jupyter_book/book_template/_includes/buttons/github_edit.html
+++ b/jupyter_book/book_template/_includes/buttons/github_edit.html
@@ -1,0 +1,3 @@
+{% if site.use_edit_on_github_button %}
+<a href="https://github.com/{{ site.edit_repo_org }}/{{ site.edit_repo_name }}/edit/{{ site.edit_repo_branch }}/{{ page.interact_link }}"><button class="interact-button" id="interact-button-edit" alt="Edit on GitHub">Edit on GitHub</button></a>
+{% endif %}


### PR DESCRIPTION
Inspired from a recent awesome demo from @gregcaporaso, this PR adds an "edit this page on GitHub" option for books. It'll add a button that takes you to an "edit this page" view on GitHub, pointing to that page.

It doesn't have the fanciness of the QIIME "line number finder", but I'm not sure how to do that with the current build system, so it seems like an "edit this page" button is a decent start!