### PR TITLE
fixing tests and prep for new release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,11 +51,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -yq $(cat .github/workflows/pyppeteer_reqs.txt)
 
-    - name: Install texlive
-      run: |
-        bash scripts/install_latex.sh
-        export PATH="/tmp/texlive/bin/x86_64-linux:$PATH"
-
     # Tests
     - name: Run pytest
       run: |

--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -1,7 +1,7 @@
 # Advanced topics and how-tos
 
 This page contains more advanced and complete information about the
-[`jupyter-book` repository](https://github.com/jupyter/jupyter-book). See the sections below.
+[`jupyter-book` repository](https://github.com/ExecutableBookProject/jupyter-book). See the sections below.
 
 
 ## Enable Google Analytics
@@ -150,10 +150,10 @@ check out these resources:
 
 * **[This blog post on pushing changes from a CircleCI Job](https://predictablynoisy.com/circleci-mirror)**
   covers how you can give CircleCI permissions to push to a branch from within a job.
-* **[The Jupyter Book CircleCI configuration file](https://github.com/jupyter/jupyter-book/blob/master/.circleci/config.yml)**
+* **[The Jupyter Book CircleCI configuration file](https://github.com/ExecutableBookProject/jupyter-book/blob/master/.circleci/config.yml)**
   automatically deploys changes to the `jupyter-book` master branch to the live book. In
-  particular, [this section builds the book HTML files](https://github.com/jupyter/jupyter-book/blob/master/.circleci/config.yml#L74)
-  while [this section builds the HTML and pushes them to a `gh-pages` branch](https://github.com/jupyter/jupyter-book/blob/master/.circleci/config.yml#L31).
+  particular, [this section builds the book HTML files](https://github.com/ExecutableBookProject/jupyter-book/blob/master/.circleci/config.yml#L74)
+  while [this section builds the HTML and pushes them to a `gh-pages` branch](https://github.com/ExecutableBookProject/jupyter-book/blob/master/.circleci/config.yml#L31).
 
 This process can be tricky to set up initially, but is quite useful in ensuring that your live book
 always stays up-to-date.

--- a/docs/customize/faq.md
+++ b/docs/customize/faq.md
@@ -28,7 +28,7 @@ Note that, if viewing the file on a Jupyter Notebook session, the figure will no
 ## What if I have an issue or question?
 
 If you've got questions, concerns, or suggestions, please open an issue at
-[at the jupyter book issues page](https://github.com/jupyter/jupyter-book/issues)
+[at the jupyter book issues page](https://github.com/ExecutableBookProject/jupyter-book/issues)
 
 ## How should I add cell tags to my notebooks?
 

--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,14 @@ setup(
     name="jupyter-book",
     version=version,
     python_requires=">=3.6",
-    author="Project Jupyter Contributors",
+    author="Executable Book Project",
     author_email="jupyter@googlegroups.com",
-    url="https://jupyterbook.org/",
+    url="https://executablebooks.org/",
     project_urls={
         "Documentation": "https://jupyterbook.org",
-        "Funding": "https://jupyter.org/about",
-        "Source": "https://github.com/jupyter/jupyter-book/",
-        "Tracker": "https://github.com/jupyter/jupyter-book/issues",
+        "Funding": "https://executablebooks.org",
+        "Source": "https://github.com/ExecutableBookProject/jupyter-book/",
+        "Tracker": "https://github.com/ExecutableBookProject/jupyter-book/issues",
     },
     # this should be a whitespace separated string of keywords, not a list
     keywords="reproducible science environments scholarship notebook",
@@ -45,25 +45,16 @@ setup(
         "pyyaml",
         "docutils>=0.15",
         "sphinx<3",
-        (
-            "myst-nb @ "
-            "https://github.com/ExecutableBookProject/myst-nb/archive/master.zip"  # noqa E501
-        ),
+        "myst-nb",
         "click",
         "setuptools",
         "nbformat",
         "nbconvert",
         "nbclient",
-        (
-            "sphinx_togglebutton @ "
-            "https://github.com/ExecutableBookProject/sphinx-togglebutton/archive/master.zip"  # noqa E501
-        ),
+        "sphinx_togglebutton",
         "sphinx-copybutton",
         "sphinxcontrib-bibtex",
-        (
-            "sphinx_book_theme @ "
-            "https://github.com/ExecutableBookProject/sphinx-book-theme/archive/master.zip"  # noqa E501
-        ),
+        "sphinx_book_theme",
     ],
     extras_require={
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],


### PR DESCRIPTION
Removes texlive install from github actions since we don't test the PDF build there.

closes https://github.com/ExecutableBookProject/jupyter-book/issues/514